### PR TITLE
font.h - add external declaration

### DIFF
--- a/font.h
+++ b/font.h
@@ -27,6 +27,6 @@ struct font {
 	uint8_t data[];
 };
 
-const struct font font;
+extern const struct font font;
 
 #endif


### PR DESCRIPTION
This is a real bug, but it only breaks on newer compilers.